### PR TITLE
Dockerfile: switch to 3.7-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.7
+FROM python:3.7-alpine
+
+RUN apk add libmagic
 
 WORKDIR /app/service
 COPY ./requirements.txt ./requirements.txt


### PR DESCRIPTION
Default Python 3.7 image is based on Debian which contains old version
of libmagic. Switch to alpine to get a newer one (5.39).