### PR TITLE
Login to DR only on push actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
+        if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
We use the `docker/build-push-action@v2.2.1` step to test-build the docker images.

The images are pushed only the `push` action by specifying it like so: `push: ${{ github.event_name == 'push' }}` but the `docker/login-action@v1` action is ran always.

This causes problems because the environment secrets are exposed only on the master branch
