### PR TITLE
Classify JSON files

### DIFF
--- a/karton/classifier/classifier.py
+++ b/karton/classifier/classifier.py
@@ -388,7 +388,7 @@ class Classifier(Karton):
                 {"kind": "document", "platform": "win32", "extension": "pdf"}
             )
             return sample_class
-            
+
         # JSON files
         if magic == "JSON data" or magic_mime == "application/json":
             sample_class.update({"kind": "json"})

--- a/karton/classifier/classifier.py
+++ b/karton/classifier/classifier.py
@@ -388,6 +388,11 @@ class Classifier(Karton):
                 {"kind": "document", "platform": "win32", "extension": "pdf"}
             )
             return sample_class
+            
+        # JSON files
+        if magic == "JSON data" or magic_mime == "application/json":
+            sample_class.update({"kind": "json"})
+            return sample_class
 
         # Archives
         archive_assoc = {


### PR DESCRIPTION
Currently JSON files are not classified with the message "Sample <name>' not recognized (unsupported type)".