### PR TITLE
Not all ELF files are for Linux

### DIFF
--- a/karton/classifier/classifier.py
+++ b/karton/classifier/classifier.py
@@ -240,8 +240,22 @@ class Classifier(Karton):
             return sample_class
 
         # Is ELF file?
+        elf_assoc = {
+            "linux": "(GNU/Linux)",
+            "freebsd": "(FreeBSD)",
+            "netbsd": "(NetBSD)",
+            "openbsd": "(SYSV)",
+            "solaris": "(Solaris)",
+        }
         if magic.startswith("ELF"):
-            sample_class.update({"kind": "runnable", "platform": "linux"})
+            for platform, platform_full in elf_assoc.items():
+                if platform_full in magic:
+                    sample_class.update(
+                        {"kind": "runnable", "platform": platform, "extension": "elf"}
+                    )
+                    return sample_class
+
+            sample_class.update({"kind": "runnable", "extension": "elf"})
             return sample_class
 
         # Is PKG file?

--- a/tests/test_classifier_runnable.py
+++ b/tests/test_classifier_runnable.py
@@ -44,11 +44,12 @@ class TestClassifier(KartonTestCase):
                 "quality": "high",
                 "kind": "runnable",
                 "mime": "application/x-executable",
-                "platform": "linux",
+                "extension": "elf",
+                "platform": "openbsd",
             },
             payload={
                 "sample": resource,
-                "tags": ["runnable:linux"],
+                "tags": ["runnable:openbsd:elf"],
                 "magic": magic,
             },
         )


### PR DESCRIPTION
This stops tagging all ELF files as `runnable:linux` and instead uses the more generic `runnable:elf`.