### PR TITLE
Fix: wrong image extension when classification is not based on magic

### DIFF
--- a/karton/classifier/classifier.py
+++ b/karton/classifier/classifier.py
@@ -393,7 +393,7 @@ class Classifier(Karton):
                 return sample_class
 
         if extension in image_assoc.keys():
-            sample_class.update({"kind": "misc", "extension": ext})
+            sample_class.update({"kind": "misc", "extension": extension})
             return sample_class
 
         # Is Disk image?


### PR DESCRIPTION
I guess it's pretty rare but if we provide file with extension `image.jpg` that actually isn't an image file, it will be recognized as `misc:png`  >.<
